### PR TITLE
S3 Bucket permissions: block public access

### DIFF
--- a/cloudformation/lambda-bucket.yaml
+++ b/cloudformation/lambda-bucket.yaml
@@ -100,6 +100,11 @@ Resources:
         BucketName: !Ref 'S3BucketName'
         WebsiteConfiguration:
           IndexDocument: "index.html"
+        PublicAccessBlockConfiguration: 
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
 
     S3BucketPolicy:
       Type: AWS::S3::BucketPolicy


### PR DESCRIPTION
Changes to S3 allow us to block public access to buckets that will not need to be accessed from outside the account. 
This adds the new properties to this S3 bucket because it is created by Cloudformation.

More info:
The [`PublicAccessBlockConfiguration property`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-publicaccessblockconfiguration).
The [`PublicAccessBlockConfiguration object`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html). 